### PR TITLE
fix: remove duplicate 'cds-' prefix in image names

### DIFF
--- a/.github/workflows/build-cds-containers.yml
+++ b/.github/workflows/build-cds-containers.yml
@@ -49,16 +49,16 @@ jobs:
       fail-fast: false
       matrix:
         image:
-          - name: cds-tools
+          - name: tools
             path: cds-containers/tools
             description: "CDS tools container with Bazel, Terraform, Helm, kubectl, NGC CLI, etc."
-          - name: cds-grafana-backup-tool
+          - name: grafana-backup-tool
             path: cds-containers/grafana-backup-tool
             description: "Grafana backup tool container"
-          - name: cds-go-dev-1.24-alpine
+          - name: go-dev-1.24-alpine
             path: cds-containers/go-dev-1.24-alpine
             description: "Go 1.24 development container (Alpine-based, minimal size)"
-          - name: cds-go-dev-1.24-debian
+          - name: go-dev-1.24-debian
             path: cds-containers/go-dev-1.24-debian
             description: "Go 1.24 development container (Debian-based, better compatibility)"
     


### PR DESCRIPTION
## 🐛 Problem

Test jobs failed after merging PR #16 because of incorrect image names:
https://github.com/NVIDIA/dsx-github-actions/actions/runs/21131015559

**What was pushed**:
```
❌ ghcr.io/nvidia/dsx-cds-cds-tools:0.0.1
❌ ghcr.io/nvidia/dsx-cds-cds-go-dev-1.24-alpine:0.0.1
```

**What test jobs tried to pull**:
```
✅ ghcr.io/nvidia/dsx-cds-tools:0.0.1
✅ ghcr.io/nvidia/dsx-cds-go-dev-1.24-alpine:0.0.1
```

Result: `Error response from daemon: manifest unknown`

## 🔍 Root Cause

Matrix image names already contained `cds-` prefix:
- `name: cds-tools`
- `name: cds-go-dev-1.24-alpine`

When combined with `IMAGE_PREFIX='dsx-cds-'`, it created double prefix:
```
ghcr.io/nvidia/dsx-cds- + cds-tools = ghcr.io/nvidia/dsx-cds-cds-tools ❌
```

## 🔧 Changes

Removed `cds-` prefix from matrix image names:

| Before | After |
|--------|-------|
| `cds-tools` | `tools` |
| `cds-grafana-backup-tool` | `grafana-backup-tool` |
| `cds-go-dev-1.24-alpine` | `go-dev-1.24-alpine` |
| `cds-go-dev-1.24-debian` | `go-dev-1.24-debian` |

## ✅ Expected Result

Correct image names:
- ✅ `ghcr.io/nvidia/dsx-cds-tools:0.0.1`
- ✅ `ghcr.io/nvidia/dsx-cds-grafana-backup-tool:0.0.1`
- ✅ `ghcr.io/nvidia/dsx-cds-go-dev-1.24-alpine:0.0.1`
- ✅ `ghcr.io/nvidia/dsx-cds-go-dev-1.24-debian:0.0.1`

Test jobs will successfully pull and test the images.