### PR TITLE
chore: pin codeql-action/upload-sarif to commit SHA

### DIFF
--- a/.github/actions/trivy-scan/action.yml
+++ b/.github/actions/trivy-scan/action.yml
@@ -95,7 +95,7 @@ runs:
 
     - name: Upload SARIF Report
       if: steps.check_sarif.outputs.exists == 'true' && inputs.upload-sarif == 'true'
-      uses: github/codeql-action/upload-sarif@v4.31.5
+      uses: github/codeql-action/upload-sarif@fdbfb4d2750291e159f0156def62b853c2798ca2 # v4.31.5
       with:
         sarif_file: 'vulnerability-scan-results.sarif'
         token: ${{ inputs.github-token }}


### PR DESCRIPTION
## Summary
- Pin `github/codeql-action/upload-sarif` to its commit SHA (`fdbfb4d2750291e159f0156def62b853c2798ca2`) instead of the mutable `v4.31.5` tag, following NVIDIA security guidance for action version pinning.

## Test plan
- [x] Verified that the `v4.31.5` annotated tag dereferences to commit `fdbfb4d2750291e159f0156def62b853c2798ca2` via the GitHub API