### PR TITLE
fix(go-test): remove empty expression from comment

### DIFF
--- a/.github/actions/go-test/action.yml
+++ b/.github/actions/go-test/action.yml
@@ -112,7 +112,7 @@ runs:
         INPUT_JUNIT: ${{ inputs.junit }}
         INPUT_JUNIT_FILE: ${{ inputs.junit-file }}
       run: |
-        # Build test flags (env vars prevent shell injection from ${{ }} interpolation)
+        # Build test flags (env vars prevent shell injection from expression interpolation)
         TEST_FLAGS="$INPUT_TEST_FLAGS"
         if [ "$INPUT_RACE" = "true" ]; then
           TEST_FLAGS="-race ${TEST_FLAGS}"


### PR DESCRIPTION
## Summary

GitHub Actions' template parser evaluates `${{ }}` expressions even inside shell comments in `run:` blocks. The empty `${{ }}` in the go-test action comment caused a parse failure:

```
Error: (Line: 114, Col: 12): An expression was expected
```

## Fix

Replace the literal `${{ }}` in the comment with plain text.

## Test plan

- [ ] auth-callout CI unit-test job passes with this fix