### PR TITLE
chore: add .gitignore and CODEOWNERS for SCM compliance

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Default code owners for dsx-github-actions
+* @mmou-nv @huaweic-nv @abegnoche @lachen-nv

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,20 @@
+# IDE
+.vscode/
+.idea/
+*.swp
+*.swo
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Secrets / local config
+.env
+.env.*
+*.local
+
+# Node
+node_modules/
+
+# Helm
+*.tgz


### PR DESCRIPTION
## Summary
- Add `.gitignore` to prevent committing local config, IDE files, and secrets
- Add `.github/CODEOWNERS` to define default code review ownership (@mmou-nv @huaweic-nv @abegnoche @lachen-nv)

## Why
Required for SCM Standard compliance (Source Code Management).

🤖 Generated with [Claude Code](https://claude.com/claude-code)