### PR TITLE
fix: upgrade terragrunt 0.99.5 → 1.0.1 to resolve CVEs

### DIFF
--- a/cds-containers/tools/Dockerfile
+++ b/cds-containers/tools/Dockerfile
@@ -103,7 +103,7 @@ RUN curl -fsSL -o terraform.zip "https://releases.hashicorp.com/terraform/${TERR
     && terraform --version
 
 # terragrunt
-ARG TERRAGRUNT_VERSION="0.99.5"
+ARG TERRAGRUNT_VERSION="1.0.1"
 RUN curl -fsSL -o terragrunt "https://github.com/gruntwork-io/terragrunt/releases/download/v${TERRAGRUNT_VERSION}/terragrunt_linux_amd64" \
     && mv ./terragrunt /usr/local/bin/terragrunt \
     && chmod +x /usr/local/bin/terragrunt \


### PR DESCRIPTION
Addresses up to 6 vulnerability findings from nSpect on-demand scan:
- GHSA-p77j-4mvh-x3m3 (Critical) grpc-go
- GHSA-9h8m-3fm2-qjrq (High) otel/sdk
- GHSA-78h2-9frx-2jm8 (High) go-jose
- GHSA-6g7g-w4f8-9c9x (High) jsonparser
- GHSA-hfvc-g4fc-pqhx (High) otel/sdk
- GHSA-92mm-2pjq-r785 (High) go-getter

## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/dsx-github-actions/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
