### PR TITLE
fix(docker-build): route BuildKit pulls through the NVIDIA Docker Hub mirror

### DIFF
--- a/.github/actions/docker-build/action.yml
+++ b/.github/actions/docker-build/action.yml
@@ -122,6 +122,8 @@ runs:
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
+      with:
+        buildkitd-config: /etc/buildkit/buildkitd.toml
 
     - name: Prepare security scan vars
       if: inputs.security-scan-enabled == 'true'

--- a/.github/actions/security-container-scan/README.md
+++ b/.github/actions/security-container-scan/README.md
@@ -39,6 +39,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          buildkitd-config: /etc/buildkit/buildkitd.toml
+
       - name: Build image locally
         uses: docker/build-push-action@v5
         with:
@@ -67,6 +72,11 @@ jobs:
       security-events: write   # required for SARIF upload
     steps:
       - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          buildkitd-config: /etc/buildkit/buildkitd.toml
 
       - name: Build image locally
         uses: docker/build-push-action@v5

--- a/.github/workflows/build-cds-containers.yml
+++ b/.github/workflows/build-cds-containers.yml
@@ -81,6 +81,8 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+        with:
+          buildkitd-config: /etc/buildkit/buildkitd.toml
 
       - name: Log in to GitHub Container Registry
         if: github.ref == 'refs/heads/main'


### PR DESCRIPTION
## Summary

Configures `docker/setup-buildx-action` to read `/etc/buildkit/buildkitd.toml`, the file the `nv-gha-runners` already pre-populate. That config routes BuildKit's `docker.io` pulls through `dockerhub.nvidia.com` (NVIDIA's Artifactory pull-through cache) instead of going straight to Docker Hub.

Without this, BuildKit on the self-hosted runners ignores the daemon-level mirror and pulls anonymously from Docker Hub, which hits the unauthenticated rate limit and breaks Docker builds across DSX repos.

Reference: nvbug 6225636.

## Changes

- `.github/actions/docker-build/action.yml` — the composite action consumed by downstream DSX repos. This is the load-bearing change: bumping the consumed tag is the only thing downstream repos need to do.
- `.github/workflows/build-cds-containers.yml` — this repo's own container build workflow gets the same fix.
- `.github/actions/security-container-scan/README.md` — example snippets now show the BuildKit config step so adopters copy the correct pattern.

The reusable workflow `.github/workflows/docker-build.yml` is covered transitively because it delegates to the composite action above.

Not modified (BuildKit not involved): `docker pull` / `docker build` call sites that go through the Docker daemon directly. The `nv-gha-runners` Docker daemon is already configured with `dockerhub.nvidia.com` as a registry mirror at the host level.

## Why this is the right fix

This matches the NVIDIA GHA platform team's documented best practice: https://docs.gha-runners.nvidia.com/platform/best-practices/#use-docker-cache-for-buildkit

The toml file is already on every `nv-gha-runners` runner image, so there's nothing to deploy on the infra side — this is purely a workflow-level opt-in.

## Test plan

Static validation performed locally:
- [x] `python -m yaml` parses all three edited files cleanly.
- [x] `actionlint v1.7.7` exits clean (`-no-color -oneline`) on `build-cds-containers.yml` and `docker-build.yml`. (`actionlint` does not lint composite-action manifests; `action.yml` schema is validated by GHA at action invocation.)

Live validation (requires runners; needs a vetter to allow `copy-pr-bot`):
- [ ] **This PR's own CI run.** `build-cds-containers.yml` matches the path filter on `.github/workflows/build-cds-containers.yml` and `cds-containers/**`. Once a vetter approves the `copy-pr-bot` mirror, the workflow should run on `pull-request/**` and exercise the new `buildkitd-config:` end-to-end.
- [x] **Downstream consumer smoke test** tracked separately on an internal PR (linked from nvbug 6225636).

## Rollout

After merge, cut a new tag of this action (next semver, likely `v1.17.0`). Downstream consumers pick it up via a one-line bump of the `uses:` SHA/tag — no per-repo workflow surgery required.

cc @huaweic-nv @mmou-nv @abegnoche @lachen-nv