### PR TITLE
fix(build-cds-containers): drop buildkitd-config on ubuntu-latest runners

### DIFF
--- a/.github/workflows/build-cds-containers.yml
+++ b/.github/workflows/build-cds-containers.yml
@@ -81,8 +81,6 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-        with:
-          buildkitd-config: /etc/buildkit/buildkitd.toml
 
       - name: Log in to GitHub Container Registry
         if: github.ref == 'refs/heads/main'


### PR DESCRIPTION
## Summary

Hotfix for the post-merge failure on \`main\` introduced by #48. Drops the \`buildkitd-config: /etc/buildkit/buildkitd.toml\` input from \`Set up Docker Buildx\` in \`build-cds-containers.yml\`.

## Root cause

The jobs in this workflow run on \`runs-on: ubuntu-latest\` (GitHub-hosted runners), not \`nv-gha-runners\`. \`/etc/buildkit/buildkitd.toml\` is only pre-populated on the latter. As a result, every matrix variant of \`build-and-push-images\` failed in the post-merge \`Build CDS Containers\` run with:

\`\`\`
##[error]config file /etc/buildkit/buildkitd.toml not found
\`\`\`

Failed run: https://github.com/NVIDIA/dsx-github-actions/actions/runs/26478414457

## Why this revert is safe

The fix in #48 targeted Docker Hub anonymous rate limits on self-hosted runners. GitHub-hosted runners pull Docker Hub images using the runner's pre-configured Docker Hub auth, which is not subject to the anonymous rate limit. So this workflow never needed the BuildKit mirror config in the first place.

## What stays

- \`.github/actions/docker-build/action.yml\` — the composite action consumed by \`nv-gha-runners\`-based downstream repos. Unchanged from #48 and correct.
- \`.github/actions/security-container-scan/README.md\` — examples target \`linux-amd64-cpu4\` (an nv-gha-runner). Unchanged from #48 and correct.

## Lesson learned (for the audit)

When applying \`buildkitd-config: /etc/buildkit/buildkitd.toml\`, confirm the surrounding job's \`runs-on:\` is an nv-gha-runner. The path is platform-specific.

## Test plan

- [x] \`python -m yaml\` parses \`.github/workflows/build-cds-containers.yml\` cleanly.
- [x] \`actionlint v1.7.7\` exits clean on \`.github/workflows/build-cds-containers.yml\`.
- [ ] Post-merge \`Build CDS Containers\` run on \`main\` succeeds.

Tracks: nvbug 6225636.

cc @huaweic-nv @mmou-nv @abegnoche @lachen-nv