### PR TITLE
refactor(build-cds-containers): run on nv-gha-runners (supersedes #49)

### DIFF
--- a/.github/workflows/build-cds-containers.yml
+++ b/.github/workflows/build-cds-containers.yml
@@ -34,7 +34,7 @@ env:
 jobs:
   # Job 1: Read version from VERSION.md
   get-version:
-    runs-on: ubuntu-latest
+    runs-on: linux-amd64-cpu4
     permissions:
       contents: read
     outputs:
@@ -53,7 +53,7 @@ jobs:
 
   # Job 2: Build and push all container images
   build-and-push-images:
-    runs-on: ubuntu-latest
+    runs-on: linux-amd64-cpu4
     permissions:
       contents: read
       packages: write  # Required to push to GHCR
@@ -139,7 +139,7 @@ jobs:
 
   # Job 3: Test using the built go-dev image
   test-go-dev-image:
-    runs-on: ubuntu-latest
+    runs-on: linux-amd64-cpu4
     permissions:
       contents: read
       packages: read
@@ -181,7 +181,7 @@ jobs:
 
   # Job 4: Test using tools container
   test-tools-image:
-    runs-on: ubuntu-latest
+    runs-on: linux-amd64-cpu4
     permissions:
       contents: read
       packages: read
@@ -219,7 +219,7 @@ jobs:
 
   # Job 5: Summary
   summary:
-    runs-on: ubuntu-latest
+    runs-on: linux-amd64-cpu4
     permissions:
       contents: read
     needs: [get-version, build-and-push-images, test-go-dev-image, test-tools-image]


### PR DESCRIPTION
## Summary -- alternative to #49

This PR is the architectural alternative to the revert in #49. It moves all five jobs in `build-cds-containers.yml` from `runs-on: ubuntu-latest` to `runs-on: linux-amd64-cpu4` (NVIDIA self-hosted runners), and keeps the `buildkitd-config: /etc/buildkit/buildkitd.toml` setting introduced in #48. With the workflow on nv-gha-runners, that config does meaningful work — BuildKit routes `docker.io` pulls through `dockerhub.nvidia.com` (Artifactory pull-through cache) instead of going anonymously to Docker Hub.

Reviewers: please pick **either this PR or #49**, not both.

## Why this is worth considering

Three of the four matrix builds pull their base image from Docker Hub today:

| Image | `FROM` | Hits docker.io? |
|---|---|---|
| `tools` | `nvcr.io/nvidia/base/ubuntu:22.04_20240212` | No |
| `grafana-backup-tool` | `ysde/docker-grafana-backup-tool:1.4.2-slim` | Yes |
| `go-dev-1.24-debian` | `golang:1.24.3` | Yes |
| `go-dev-1.24-alpine` | `golang:1.24.3-alpine` | Yes |

That means the rate-limit risk that motivated #48 applies here too — it just happens to be masked today because GitHub-hosted runners get authenticated Docker Hub pulls. Moving to nv-gha-runners makes the workflow consistent with the rest of this repo and protected from the rate-limit class of failures.

## Trade-offs vs. #49

| Concern | #49 (revert) | This PR (refactor) |
|---|---|---|
| Unbreaks `main` | Yes, immediately | Yes, by superseding |
| Code change | -2 lines | 5 `runs-on:` line edits, 0 new logic |
| Consistency with rest of repo | Workflow stays the odd one out on GitHub-hosted | Aligned with composite action, reusable workflow, README examples |
| Rate-limit protection on docker.io pulls | None (relies on GitHub-hosted's pre-auth) | Full (mirror config now applies) |
| Risk | Zero | Slightly higher — nv-gha-runners must support the workflow's other deps (GHA cache backend, GHCR push, `docker run` tests) |
| Reviewer cost | Trivial | Needs a yes on platform direction |

## Open questions for reviewers

1. **Was `ubuntu-latest` originally intentional** (e.g., to keep the workflow runnable by external contributors, or to decouple from internal infra)?
2. **Do `nv-gha-runners` support the workflow's auxiliary steps** as-is? Specifically:
   - `cache-from: type=gha` / `cache-to: type=gha,mode=max` — GHA cache backend (should be runner-agnostic).
   - `docker/login-action@v3` against `ghcr.io` with `${{ secrets.GITHUB_TOKEN }}`.
   - `docker run` invocations in the `test-go-dev-image` and `test-tools-image` jobs against the freshly built images.
3. **Resource sizing** — `linux-amd64-cpu4` is 4 CPUs; comparable to GitHub-hosted standard tier. Disk size should be fine for these images. Sanity-check before merge.

## What stays unchanged

- `.github/actions/docker-build/action.yml` — composite action consumed by `nv-gha-runners`-based downstream repos. Correct as-is from #48.
- `.github/actions/security-container-scan/README.md` — examples target `linux-amd64-cpu4`. Correct as-is from #48.

## Test plan

Static validation performed locally:
- [x] `python -m yaml` parses `.github/workflows/build-cds-containers.yml` cleanly.
- [x] `actionlint v1.7.7` exits clean (one pre-existing warning about `linux-amd64-cpu4` being unrecognized by upstream actionlint — this is a known limitation for self-hosted labels, no actual issue).

Live validation (requires runners; needs a vetter to allow `copy-pr-bot`):
- [ ] `Build CDS Containers` runs on `pull-request/**` mirror (path filter matches because the workflow file itself changed).
- [ ] All four matrix variants succeed on `nv-gha-runners`.
- [ ] Test jobs (`test-go-dev-image`, `test-tools-image`) succeed.

Tracks: nvbug 6225636.

cc @huaweic-nv @mmou-nv @abegnoche @lachen-nv