### PR TITLE
fix(resource-push-ngc): download arm64 NGC CLI on arm64 runners

### DIFF
--- a/.github/actions/resource-push-ngc/scripts/install-ngc-cli.sh
+++ b/.github/actions/resource-push-ngc/scripts/install-ngc-cli.sh
@@ -31,7 +31,16 @@ if command -v ngc >/dev/null 2>&1; then
 fi
 
 NGCCLI_VERSION="${NGCCLI_VERSION:-4.9.17}"
-download_url="https://api.ngc.nvidia.com/v2/resources/nvidia/ngc-apps/ngc_cli/versions/${NGCCLI_VERSION}/files/ngccli_linux.zip"
+
+# NGC ships a separate CLI build per architecture. ngccli_linux.zip is x86_64-only —
+# running it on an arm64 runner fails with "cannot execute binary file: Exec format error",
+# so select the matching archive for the runner's architecture.
+case "$(uname -m)" in
+  x86_64 | amd64) ngc_cli_file="ngccli_linux.zip" ;;
+  aarch64 | arm64) ngc_cli_file="ngccli_arm64.zip" ;;
+  *) log_error "Unsupported architecture for NGC CLI: $(uname -m)"; exit 1 ;;
+esac
+download_url="https://api.ngc.nvidia.com/v2/resources/nvidia/ngc-apps/ngc_cli/versions/${NGCCLI_VERSION}/files/${ngc_cli_file}"
 work_dir=$(mktemp -d)
 trap 'rm -rf "$work_dir"' EXIT
 


### PR DESCRIPTION
## Problem
`install-ngc-cli.sh` hardcodes `ngccli_linux.zip` (x86_64). On an arm64 runner the CLI fails with `cannot execute binary file: Exec format error` (exit 126), so `resource-push-ngc` can't upload from arm64 jobs.

## Fix
Select the archive by runner arch: x86_64 → `ngccli_linux.zip`, aarch64 → `ngccli_arm64.zip` (confirmed to exist for v4.9.17). Unblocks NGC uploads from arm64 runners for all consumers.

## Test
Used by NVIDIA/infra-controller REST CI arm64 build legs (follow-up PR bumps the pinned SHA).