### PR TITLE
fix(security-container-scan): pin anchore/sbom-action by SHA for GHE allowlist

### DIFF
--- a/.github/actions/security-container-scan/README.md
+++ b/.github/actions/security-container-scan/README.md
@@ -4,7 +4,7 @@ A composite GitHub Action that generates an SBOM (via Syft) and scans a locally-
 
 ## Features
 
-- ✅ SBOM generation with `anchore/sbom-action` (Syft, SPDX-JSON by default)
+- ✅ SBOM generation with `anchore/sbom-action` (Syft, SPDX-JSON by default; SHA-pinned for GHE allowlist)
 - ✅ Vulnerability scan with Anchore Grype (JSON + SARIF outputs)
 - ✅ Top-N CVE summary written to `$GITHUB_STEP_SUMMARY`
 - ✅ Reports uploaded as a workflow artifact

--- a/.github/actions/security-container-scan/action.yml
+++ b/.github/actions/security-container-scan/action.yml
@@ -117,7 +117,7 @@ runs:
       id: sbom
       if: ${{ inputs.generate-sbom == 'true' && steps.precheck.outputs.image_exists == 'true' }}
       continue-on-error: true
-      uses: anchore/sbom-action@v0
+      uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
       with:
         image: ${{ inputs.image }}
         format: ${{ inputs.sbom-format }}


### PR DESCRIPTION
## Summary
- Pin `anchore/sbom-action` to `e22c389904149dbc22b58101806040fa8d37a610` (v0.24.0) instead of floating `@v0`
- NVIDIA GHE validates the literal `uses:` ref against the enterprise allowlist; `@v0` fails instantly even when the resolved SHA is allowlisted (NVBug 6457170)
- Unblocks downstream repos (e.g. `NVIDIA/infra-controller`) that consume `security-container-scan@<sha>`

## Test plan
- [x] Merge and note the new commit SHA for consumer pin bumps
- [ ] Bump `NVIDIA/dsx-github-actions/.github/actions/security-container-scan@...` in infra-controller
- [ ] Confirm a container build job passes GHE workflow validation (no instant `not allowed` on sbom-action)

## Follow-up (separate PRs)
- `docker-build/action.yml` still uses `@v3`/`@v5` docker actions (may be covered by allowlist wildcards)
- `helm-*` actions use `dcarbone/install-*@v1.x` tags — audit if those hit the same issue