### PR TITLE
feat(helm-validate): support Helm version override

### DIFF
--- a/.github/actions/helm-validate/README.md
+++ b/.github/actions/helm-validate/README.md
@@ -12,6 +12,7 @@ steps:
     uses: NVIDIA/dsx-github-actions/.github/actions/helm-validate@main
     with:
       chart-path: ./charts/my-chart
+      helm-version: v3.18.3
       valueOverrides: |
         global.env=prod
         image.tag=v1.0.0
@@ -24,6 +25,7 @@ steps:
 | Input | Description | Required | Default |
 | --- | --- | --- | --- |
 | `chart-path` | Root directory for the Helm Chart | No | . |
+| `helm-version` | Helm version to install for validation | No | v3.13.2 |
 | `lint` | Whether to lint the Helm Chart | No | true |
 | `template` | Whether to template the Helm Chart | No | true |
 | `extra-repos` | Extra repositories (JSON or "name url" per line) | No | [] |

--- a/.github/actions/helm-validate/action.yml
+++ b/.github/actions/helm-validate/action.yml
@@ -20,6 +20,10 @@ inputs:
     description: "Root directory for the Helm Chart"
     required: false
     default: "."
+  helm-version:
+    description: "Helm version to install for validation"
+    required: false
+    default: "v3.13.2"
   lint:
     description: "Whether to lint the Helm Chart"
     required: false
@@ -46,7 +50,8 @@ runs:
     - name: Install Helm
       shell: bash
       run: |
-        "${{ github.action_path }}/../helm-shared/scripts/install-helm.sh"
+        "${{ github.action_path }}/../helm-shared/scripts/install-helm.sh" \
+          "${{ inputs.helm-version }}"
 
     - name: Process Variables
       shell: bash


### PR DESCRIPTION
## What

- add an optional `helm-version` input to the shared `helm-validate` action
- preserve `v3.13.2` as the default for existing callers
- forward the selected version to the existing Helm installer
- document opting in to Helm `v3.18.3`

## Why

NVIDIA/infra-controller#3602 validates packaged chart behavior with `helm template --skip-schema-validation`. The shared action currently installs Helm `v3.13.2`, which does not recognize that flag. This allows only the affected callers to opt into `v3.18.3` without changing all current consumers.

This does not add an upstream NGC repository default or change image/AppVersion behavior.

## Validation

- `pre-commit run --files .github/actions/helm-validate/action.yml .github/actions/helm-validate/README.md`
- Linux installer smoke test with both `v3.13.2` and `v3.18.3`
- `git diff --check`