### PR TITLE
fix: harden CI supply chain and inputs

### DIFF
--- a/.github/actions/helm-shared/scripts/install-ngc.sh
+++ b/.github/actions/helm-shared/scripts/install-ngc.sh
@@ -32,12 +32,37 @@ if command -v ngc >/dev/null 2>&1; then
 fi
 
 NGCCLI_VERSION="${NGCCLI_VERSION:-4.9.17}"
-download_url="https://api.ngc.nvidia.com/v2/resources/nvidia/ngc-apps/ngc_cli/versions/${NGCCLI_VERSION}/files/ngccli_linux.zip"
+
+case "$(uname -m)" in
+  x86_64 | amd64) ngc_cli_file="ngccli_linux.zip" ;;
+  aarch64 | arm64) ngc_cli_file="ngccli_arm64.zip" ;;
+  *) log_error "Unsupported architecture for NGC CLI: $(uname -m)"; exit 1 ;;
+esac
+
+case "${NGCCLI_VERSION}:${ngc_cli_file}" in
+  4.9.17:ngccli_linux.zip)
+    expected_sha256="b1cc4299151cdcbc2bd18318c0a3b7f321f3e62e20ba234b6a8a0e7024cf3b44"
+    ;;
+  4.9.17:ngccli_arm64.zip)
+    expected_sha256="7945c17290b0bb4003b01065149a4d2f254335e56037b16d9417c1aec566e60c"
+    ;;
+  *)
+    expected_sha256="${NGCCLI_SHA256:-}"
+    if [[ -z "$expected_sha256" ]]; then
+      log_error "No trusted checksum configured for NGC CLI ${NGCCLI_VERSION} (${ngc_cli_file})"
+      exit 1
+    fi
+    ;;
+esac
+
+download_url="https://api.ngc.nvidia.com/v2/resources/nvidia/ngc-apps/ngc_cli/versions/${NGCCLI_VERSION}/files/${ngc_cli_file}"
 work_dir=$(mktemp -d)
 trap 'rm -rf "$work_dir"' EXIT
 
 log_info "Downloading NGC CLI from $download_url"
 curl -sSfL "$download_url" -o "$work_dir/ngccli.zip"
+printf '%s  %s\n' "$expected_sha256" "$work_dir/ngccli.zip" | sha256sum -c -
+log_info "Verified NGC CLI SHA256 checksum"
 unzip -q "$work_dir/ngccli.zip" -d "$work_dir"
 
 extract_dir=$(find "$work_dir" -maxdepth 2 -type d -name 'ngc-cli*' | head -n 1)

--- a/.github/actions/resource-push-ngc/README.md
+++ b/.github/actions/resource-push-ngc/README.md
@@ -32,6 +32,11 @@ jobs:
           ngccli-version: 4.9.17
 ```
 
+The default NGC CLI version has NVIDIA-published checksums built into the
+action for both AMD64 and ARM64. When overriding `ngccli-version`, also pass
+the matching `ngccli-sha256`; installation fails closed when no trusted
+checksum is available.
+
 ## Inputs
 
 | Name             | Required | Default             | Description                                                      |
@@ -50,6 +55,7 @@ jobs:
 | `precision`      | No       | `OTHER`             | Resource precision                                               |
 | `version`        | Yes      | —                   | Resource version                                                 |
 | `ngccli-version` | No       | `4.9.17`            | NGC CLI version to install                                       |
+| `ngccli-sha256`  | No       | empty               | Expected archive SHA256; required for non-default CLI versions   |
 
 ## Outputs
 

--- a/.github/actions/resource-push-ngc/action.yml
+++ b/.github/actions/resource-push-ngc/action.yml
@@ -68,6 +68,10 @@ inputs:
     description: "NGC CLI version to install"
     default: "4.9.17"
     required: false
+  ngccli-sha256:
+    description: "Expected SHA256 for a non-default NGC CLI version on the runner architecture"
+    default: ""
+    required: false
 outputs:
   resource-id:
     description: "Fully qualified resource identifier"
@@ -88,6 +92,7 @@ runs:
         "$GITHUB_ACTION_PATH"/scripts/install-ngc-cli.sh
       env:
         NGCCLI_VERSION: ${{ inputs.ngccli-version }}
+        NGCCLI_SHA256: ${{ inputs.ngccli-sha256 }}
     - name: Validate inputs
       shell: bash
       run: |

--- a/.github/actions/resource-push-ngc/scripts/install-ngc-cli.sh
+++ b/.github/actions/resource-push-ngc/scripts/install-ngc-cli.sh
@@ -40,12 +40,31 @@ case "$(uname -m)" in
   aarch64 | arm64) ngc_cli_file="ngccli_arm64.zip" ;;
   *) log_error "Unsupported architecture for NGC CLI: $(uname -m)"; exit 1 ;;
 esac
+
+case "${NGCCLI_VERSION}:${ngc_cli_file}" in
+  4.9.17:ngccli_linux.zip)
+    expected_sha256="b1cc4299151cdcbc2bd18318c0a3b7f321f3e62e20ba234b6a8a0e7024cf3b44"
+    ;;
+  4.9.17:ngccli_arm64.zip)
+    expected_sha256="7945c17290b0bb4003b01065149a4d2f254335e56037b16d9417c1aec566e60c"
+    ;;
+  *)
+    expected_sha256="${NGCCLI_SHA256:-}"
+    if [[ -z "$expected_sha256" ]]; then
+      log_error "No trusted checksum configured for NGC CLI ${NGCCLI_VERSION} (${ngc_cli_file})"
+      exit 1
+    fi
+    ;;
+esac
+
 download_url="https://api.ngc.nvidia.com/v2/resources/nvidia/ngc-apps/ngc_cli/versions/${NGCCLI_VERSION}/files/${ngc_cli_file}"
 work_dir=$(mktemp -d)
 trap 'rm -rf "$work_dir"' EXIT
 
 log_info "Downloading NGC CLI from $download_url"
 curl -sSfL "$download_url" -o "$work_dir/ngccli.zip"
+printf '%s  %s\n' "$expected_sha256" "$work_dir/ngccli.zip" | sha256sum -c -
+log_info "Verified NGC CLI SHA256 checksum"
 unzip -q "$work_dir/ngccli.zip" -d "$work_dir"
 
 extract_dir=$(find "$work_dir" -maxdepth 2 -type d -name 'ngc-cli*' | head -n 1)

--- a/.github/actions/resource-push-ngc/scripts/validate-inputs.sh
+++ b/.github/actions/resource-push-ngc/scripts/validate-inputs.sh
@@ -38,6 +38,24 @@ require_non_empty() {
   fi
 }
 
+# GitHub environment files use a delimiter for multiline values. A unique
+# delimiter keeps embedded newlines from being interpreted as new variables.
+write_env() {
+  local name=$1
+  local value=$2
+  local delimiter="ghadelimiter_${RANDOM}_${RANDOM}_$$"
+
+  while grep -Fqx -- "$delimiter" <<< "$value"; do
+    delimiter="ghadelimiter_${RANDOM}_${RANDOM}_$$"
+  done
+
+  {
+    printf '%s<<%s\n' "$name" "$delimiter"
+    printf '%s\n' "$value"
+    printf '%s\n' "$delimiter"
+  } >> "$GITHUB_ENV"
+}
+
 CC_RESOURCE_NAME=${INPUT_NAME:-}
 if [[ -n ${RESOURCE_NAME:-} ]]; then
   info "Reading name from RESOURCE_NAME"
@@ -148,17 +166,15 @@ Resource NGC Force: $CC_RESOURCE_NGC_FORCE
 Resource NGC Path: $CC_RESOURCE_NGC_PATH
 SUMMARY
 
-{
-  echo "CC_RESOURCE_NAME=$CC_RESOURCE_NAME"
-  echo "CC_RESOURCE_DISPLAY_NAME=$CC_RESOURCE_DISPLAY_NAME"
-  echo "CC_RESOURCE_DESCRIPTION=$CC_RESOURCE_DESCRIPTION"
-  echo "CC_RESOURCE_PATH=$CC_RESOURCE_PATH"
-  echo "CC_RESOURCE_VERSION=$CC_RESOURCE_VERSION"
-  echo "CC_RESOURCE_FORMAT=$CC_RESOURCE_FORMAT"
-  echo "CC_RESOURCE_APPLICATION=$CC_RESOURCE_APPLICATION"
-  echo "CC_RESOURCE_FRAMEWORK=$CC_RESOURCE_FRAMEWORK"
-  echo "CC_RESOURCE_PRECISION=$CC_RESOURCE_PRECISION"
-  echo "CC_RESOURCE_NGC_FORCE=$CC_RESOURCE_NGC_FORCE"
-  echo "CC_RESOURCE_NGC_PATH=$CC_RESOURCE_NGC_PATH"
-  echo "CC_RESOURCE_NGC_KEY=$CC_RESOURCE_NGC_KEY"
-} >> "$GITHUB_ENV"
+write_env CC_RESOURCE_NAME "$CC_RESOURCE_NAME"
+write_env CC_RESOURCE_DISPLAY_NAME "$CC_RESOURCE_DISPLAY_NAME"
+write_env CC_RESOURCE_DESCRIPTION "$CC_RESOURCE_DESCRIPTION"
+write_env CC_RESOURCE_PATH "$CC_RESOURCE_PATH"
+write_env CC_RESOURCE_VERSION "$CC_RESOURCE_VERSION"
+write_env CC_RESOURCE_FORMAT "$CC_RESOURCE_FORMAT"
+write_env CC_RESOURCE_APPLICATION "$CC_RESOURCE_APPLICATION"
+write_env CC_RESOURCE_FRAMEWORK "$CC_RESOURCE_FRAMEWORK"
+write_env CC_RESOURCE_PRECISION "$CC_RESOURCE_PRECISION"
+write_env CC_RESOURCE_NGC_FORCE "$CC_RESOURCE_NGC_FORCE"
+write_env CC_RESOURCE_NGC_PATH "$CC_RESOURCE_NGC_PATH"
+write_env CC_RESOURCE_NGC_KEY "$CC_RESOURCE_NGC_KEY"

--- a/.github/actions/security-container-scan/README.md
+++ b/.github/actions/security-container-scan/README.md
@@ -121,7 +121,7 @@ steps:
 | `image`              | Local container image reference to scan (must exist on the runner).                                                           | Yes      | —                            |
 | `fail-on`            | Minimum Grype severity that counts as a failure. One of `negligible`, `low`, `medium`, `high`, `critical`.                    | No       | `high`                       |
 | `fail-build`         | If `true`, fail the step when Grype finds vulnerabilities at/above `fail-on` or when SBOM/scan prerequisites fail.            | No       | `false`                      |
-| `grype-image`        | Grype container image to use for scanning. Override to pin to a specific digest for supply-chain hardening.                   | No       | `anchore/grype:latest`       |
+| `grype-image`        | Grype container image to use for scanning. Update the version and multi-architecture digest together.                         | No       | `anchore/grype:v0.117.0@sha256:ddf9e9f204049f3a4a0955ef70873cabab6a31432125ad4f20a490b54950a253` |
 | `report-json`        | Filename for the JSON report.                                                                                                 | No       | `grype-results.json`         |
 | `report-sarif`       | Filename for the SARIF report.                                                                                                | No       | `grype-results.sarif`        |
 | `report-table`       | Filename for the human-readable table report (always generated).                                                              | No       | `grype-results.txt`          |
@@ -148,7 +148,7 @@ steps:
 
 - **Step summary is count-only**: the `$GITHUB_STEP_SUMMARY` output shows total matches and Critical/High/Medium/Low counts, but does **not** list individual CVE IDs or affected packages. On public repositories, run summaries are world-readable, and publishing a list of unresolved CVEs + package versions amounts to handing attackers a roadmap. Per-CVE detail is available in the JSON/SARIF/table artifact (collaborators only) or, when `upload-sarif: true`, in the Security tab.
 - **Three artifact formats**: each scan produces JSON (Grype-native, used by tooling and `jq` drill-down), SARIF (GitHub code scanning / IDE viewers), and a plain-text table (drop-in readable for reviewers who don't want to touch `jq`). All three are bundled into the same workflow artifact.
-- **Supply chain**: `grype-image` defaults to `anchore/grype:latest` for ease of adoption and DB freshness. For hardened pipelines, override it to a specific digest (`anchore/grype@sha256:...`) and refresh periodically.
+- **Supply chain**: `grype-image` defaults to a versioned, multi-architecture digest. Refresh the version and digest periodically; Grype's vulnerability database still updates at runtime.
 - **SBOM generation**: enabled by default; set `generate-sbom: "false"` to skip when you only need the vulnerability scan.
 - **Multi-arch**: Grype scans the image variant that is loaded into the local Docker daemon. When the runner is `linux/amd64` and you need to scan `linux/arm64`, pull with `--platform linux/arm64` first.
 - **GHAS-free fallback**: leave `upload-sarif` at `false`. Findings still appear in the workflow artifact and job summary; the job does not fail.

--- a/.github/actions/security-container-scan/action.yml
+++ b/.github/actions/security-container-scan/action.yml
@@ -31,7 +31,7 @@ inputs:
   grype-image:
     description: 'Grype container image to run'
     required: false
-    default: anchore/grype:latest
+    default: anchore/grype:v0.117.0@sha256:ddf9e9f204049f3a4a0955ef70873cabab6a31432125ad4f20a490b54950a253
   report-json:
     description: 'Filename for JSON report'
     required: false

--- a/.github/actions/semantic-release/action.yml
+++ b/.github/actions/semantic-release/action.yml
@@ -112,18 +112,24 @@ runs:
     - name: Display Release Info
       if: steps.semantic.outputs.new_release_published == 'true'
       shell: bash
+      env:
+        RELEASE_VERSION: ${{ steps.semantic.outputs.new_release_version }}
+        RELEASE_TAG: ${{ steps.semantic.outputs.new_release_git_tag }}
+        RELEASE_NOTES: ${{ steps.semantic.outputs.new_release_notes }}
       run: |
         echo "🎉 New Release Published!"
-        echo "📦 Version: ${{ steps.semantic.outputs.new_release_version }}"
-        echo "🏷️ Tag: ${{ steps.semantic.outputs.new_release_git_tag }}"
+        printf '📦 Version: %s\n' "$RELEASE_VERSION"
+        printf '🏷️ Tag: %s\n' "$RELEASE_TAG"
         echo "📝 Release Notes:"
-        echo "${{ steps.semantic.outputs.new_release_notes }}"
+        printf '%s\n' "$RELEASE_NOTES"
 
     - name: No Release Info
       if: steps.semantic.outputs.new_release_published != 'true'
       shell: bash
+      env:
+        LAST_RELEASE_VERSION: ${{ steps.semantic.outputs.last_release_version }}
       run: |
         echo "ℹ️ No new release created"
-        if [ -n "${{ steps.semantic.outputs.last_release_version }}" ]; then
-          echo "📌 Last release: ${{ steps.semantic.outputs.last_release_version }}"
+        if [ -n "$LAST_RELEASE_VERSION" ]; then
+          printf '📌 Last release: %s\n' "$LAST_RELEASE_VERSION"
         fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,9 +45,12 @@ jobs:
 
       - name: Update Major Version Tag
         if: steps.semantic.outputs.new-release-published == 'true'
+        env:
+          NEW_RELEASE_VERSION: ${{ steps.semantic.outputs.new-release-version }}
+          NEW_RELEASE_MAJOR_VERSION: ${{ steps.semantic.outputs.new-release-major-version }}
         run: |
-          NEW_VERSION="v${{ steps.semantic.outputs.new-release-version }}"
-          MAJOR_VERSION="v${{ steps.semantic.outputs.new-release-major-version }}"
+          NEW_VERSION="v${NEW_RELEASE_VERSION}"
+          MAJOR_VERSION="v${NEW_RELEASE_MAJOR_VERSION}"
 
           # Configure git
           git config user.name "github-actions[bot]"
@@ -62,14 +65,16 @@ jobs:
       - name: Prepare Release Notes for Slack
         if: steps.semantic.outputs.new-release-published == 'true'
         id: prepare-notes
+        env:
+          RELEASE_NOTES: ${{ steps.semantic.outputs.new-release-notes }}
         run: |
           # Truncate and escape release notes for JSON
-          NOTES=$(echo '${{ steps.semantic.outputs.new-release-notes }}' | head -c 2000 | jq -Rs .)
-          echo "notes=$NOTES" >> $GITHUB_OUTPUT
+          NOTES=$(printf '%s' "$RELEASE_NOTES" | head -c 2000 | jq -Rs .)
+          echo "notes=$NOTES" >> "$GITHUB_OUTPUT"
 
           # Also create a simple summary
-          SUMMARY=$(echo '${{ steps.semantic.outputs.new-release-notes }}' | head -n 3 | sed 's/^# //' | tr '\n' ' ')
-          echo "summary=$SUMMARY" >> $GITHUB_OUTPUT
+          SUMMARY=$(printf '%s\n' "$RELEASE_NOTES" | head -n 3 | sed 's/^# //' | tr '\n' ' ' | jq -Rs .)
+          echo "summary=$SUMMARY" >> "$GITHUB_OUTPUT"
 
       - name: Notify Slack - Release Published
         if: steps.semantic.outputs.new-release-published == 'true'
@@ -113,7 +118,7 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "${{ steps.prepare-notes.outputs.summary }}"
+                    "text": ${{ steps.prepare-notes.outputs.summary }}
                   }
                 },
                 {

--- a/cds-containers/tools/Dockerfile
+++ b/cds-containers/tools/Dockerfile
@@ -35,10 +35,17 @@ RUN apt-get update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-# Install Node.js 24 LTS
-RUN curl -fsSL https://deb.nodesource.com/setup_24.x | bash - \
+# Install Node.js 24 LTS from the signed NodeSource repository. Pin the signing
+# key identity instead of executing the remote setup script.
+ARG NODESOURCE_GPG_FINGERPRINT="6F71F525282841EEDAF851B42F59B5F99B1BE0B4"
+RUN curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key -o /tmp/nodesource-repo.gpg.key \
+    && test "$(gpg --batch --show-keys --with-colons /tmp/nodesource-repo.gpg.key | awk -F: '$1 == "fpr" { print $10; exit }')" = "$NODESOURCE_GPG_FINGERPRINT" \
+    && gpg --batch --yes --dearmor -o /usr/share/keyrings/nodesource.gpg /tmp/nodesource-repo.gpg.key \
+    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/nodesource.gpg] https://deb.nodesource.com/node_24.x nodistro main" > /etc/apt/sources.list.d/nodesource.list \
+    && rm /tmp/nodesource-repo.gpg.key \
     && apt-get update \
     && apt-get install --no-install-recommends -y nodejs \
+    && rm -rf /var/lib/apt/lists/* \
     && node --version \
     && npm --version
 
@@ -68,7 +75,9 @@ RUN curl -fsSL -o yq "https://github.com/mikefarah/yq/releases/download/v${YQ_VE
 
 # ngccli
 ARG NGCCLI_VERSION="4.17.0"
-RUN curl -sSL -O "https://api.ngc.nvidia.com/v2/resources/nvidia/ngc-apps/ngc_cli/versions/${NGCCLI_VERSION}/files/ngccli_linux.zip" \
+ARG NGCCLI_SHA256="43a28b1b004c07c8e2db08595b3d5b9d4ddc496e81ef1f6b25eca8d3c79fedc6"
+RUN curl -fsSL -o ngccli_linux.zip "https://api.ngc.nvidia.com/v2/resources/nvidia/ngc-apps/ngc_cli/versions/${NGCCLI_VERSION}/files/ngccli_linux.zip" \
+    && printf '%s  %s\n' "$NGCCLI_SHA256" ngccli_linux.zip | sha256sum -c - \
     && unzip ngccli_linux.zip \
     && rm ngccli_linux.zip \
     && ln -s /ngc-cli/ngc /usr/local/bin/ngc \
@@ -104,9 +113,13 @@ RUN curl -fsSL -o regctl "https://github.com/regclient/regclient/releases/downlo
     && regctl version
 
 # helm
-ENV VERIFY_CHECKSUM=true \
-    VERIFY_SIGNATURES=false
-RUN curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash \
+ARG HELM_VERSION="4.2.3"
+ARG HELM_SHA256="e9b88b4ee95b18c706839c28d3a0220e5bc470e9cd9262410c90793c45ff8b7c"
+RUN curl -fsSL -o helm.tar.gz "https://get.helm.sh/helm-v${HELM_VERSION}-linux-amd64.tar.gz" \
+    && printf '%s  %s\n' "$HELM_SHA256" helm.tar.gz | sha256sum -c - \
+    && tar -xzf helm.tar.gz linux-amd64/helm \
+    && mv linux-amd64/helm /usr/local/bin/helm \
+    && rm -rf helm.tar.gz linux-amd64 \
     && helm version
 
 # terraform


### PR DESCRIPTION
## Summary

- keep semantic-release data out of shell source and JSON-encode release-note output before building the Slack payload
- write action inputs to `GITHUB_ENV` with collision-safe multiline delimiters
- verify NGC CLI, NodeSource, and Helm downloads before installation, failing closed when a custom NGC version has no checksum
- pin the Grype scanner to a versioned multi-architecture digest while preserving local-image scanning

## Security impact

This addresses the five current AIVO findings for expression injection, environment-file injection, unchecked downloads, remote scripts piped to a shell, and a mutable privileged scanner image.

The Grype action still mounts the Docker socket because it scans images in the runner's local daemon. Pinning the scanner digest removes the mutable-image path without changing that existing behavior.

## Compatibility

- existing required inputs and the default NGC CLI version are preserved
- callers that override the default NGC CLI version must now provide `ngccli-sha256`
- the tools image keeps Node.js 24 and pins Helm to v4.2.3, the version selected by the previous installer during validation

## Validation

- `actionlint -color .github/workflows/release.yml`
- `shellcheck` on all changed shell scripts
- `bash -n` on all changed shell scripts
- `pre-commit run check-yaml --all-files`
- `git diff --check`
- malicious multiline input test for all `CC_RESOURCE_*` environment entries
- fail-closed test for a custom NGC CLI version without a checksum
- exact pinned Grype image smoke-tested on AMD64 and ARM64
- full `cds-containers/tools/Dockerfile` build and Node/npm/Helm/NGC smoke test

The repository-wide actionlint baseline still reports pre-existing custom-runner-label and SC2086 findings in `build-cds-containers.yml`; the modified release workflow passes cleanly.
