### PR TITLE
chore: repoint CODEOWNERS to dsx-ai-factory/dsx-sw-admins (post-transfer)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,11 @@
 # Default code owners for dsx-github-actions
-* @mmou-nv @huaweic-nv @abegnoche @lachen-nv
+#
+# Post-transfer to dsx-ai-factory: code owners resolve via the org team
+# (IdP-synced from the access-dsx-owner DL) instead of individuals, so
+# ownership survives the org move without per-person maintenance.
+#
+# DO NOT MERGE until AFTER the SCM transfer to dsx-ai-factory lands:
+#   - while the repo is still under NVIDIA, @dsx-ai-factory/... will not resolve
+#   - after cutover, also grant the team write+ on the repo and keep
+#     "Require review from Code Owners" enabled in the branch ruleset
+* @dsx-ai-factory/dsx-sw-admins

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,11 +1,5 @@
 # Default code owners for dsx-github-actions
 #
-# Post-transfer to dsx-ai-factory: code owners resolve via the org team
-# (IdP-synced from the access-dsx-owner DL) instead of individuals, so
-# ownership survives the org move without per-person maintenance.
-#
-# DO NOT MERGE until AFTER the SCM transfer to dsx-ai-factory lands:
-#   - while the repo is still under NVIDIA, @dsx-ai-factory/... will not resolve
-#   - after cutover, also grant the team write+ on the repo and keep
-#     "Require review from Code Owners" enabled in the branch ruleset
+# Ownership resolves via the org team (IdP-synced from the access-dsx-owner DL)
+# rather than individuals, so it survives org moves without per-person upkeep.
 * @dsx-ai-factory/dsx-sw-admins


### PR DESCRIPTION
## What
Repoint `.github/CODEOWNERS` from the four individual owners to the org team **`@dsx-ai-factory/dsx-sw-admins`** (IdP-synced from the `access-dsx-owner` DL).

```
- * @mmou-nv @huaweic-nv @abegnoche @lachen-nv
+ * @dsx-ai-factory/dsx-sw-admins
```

## Why
This repo is moving from `NVIDIA` to the new `dsx-ai-factory` org via SCM transfer. Team access and individual code-owner entries are **org-scoped and do not travel** across orgs. Switching to the org team means ownership survives the move via IdP/DL sync, with no per-person onboarding to maintain. The four current owners are being onboarded to `dsx-ai-factory` (via `access-dsx-owner`) in parallel.

## DRAFT — do not merge until AFTER cutover
`@dsx-ai-factory/dsx-sw-admins` will **not resolve** while the repo is still under `NVIDIA`. Merge only once the SCM transfer to `dsx-ai-factory` completes. Post-cutover checklist:
- [ ] SCM transfer to `dsx-ai-factory` complete
- [ ] Grant `dsx-sw-admins` admin + `dsx-sw-developers` push on the transferred repo
- [ ] `access-dsx-owner` DL populated with mmou-nv / huaweic-nv / abegnoche / lachen-nv (team membership confirmed)
- [ ] "Require review from Code Owners" enabled in the branch ruleset
- [ ] Mark ready for review and merge

Questions/coordination: #dsx-github

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated default code ownership assignment to use the administrator team.
  * Documented that ownership is synchronized through the identity provider.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->