### PR TITLE
fix: reference security-container-scan by this repo path

### DIFF
--- a/.github/actions/docker-build/action.yml
+++ b/.github/actions/docker-build/action.yml
@@ -163,7 +163,7 @@ runs:
     - name: Security scan (SBOM + Grype)
       if: inputs.security-scan-enabled == 'true'
       id: secscan
-      uses: NVIDIA/dsx-github-actions/.github/actions/security-container-scan@d8d304286ba834f32ff672d5c90782f2bbab4aea
+      uses: dsx-ai-factory/dsx-github-actions/.github/actions/security-container-scan@d8d304286ba834f32ff672d5c90782f2bbab4aea
       with:
         image: ${{ steps.scan_vars.outputs.scan_image }}
         fail-on: critical


### PR DESCRIPTION
The `docker-build` composite action referenced the `security-container-scan` action by its full `owner/repo` path, which currently only resolves through a redirect. Since both actions live in this repository, this updates the reference to the current path so it resolves directly and does not depend on a redirect staying in place.

Same pinned SHA, no behavior change — just the path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the security scanning workflow reference while preserving the existing scan configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->