### PR TITLE
fix: point release repositoryUrl at dsx-ai-factory

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "repository": {
     "type": "git",
-    "url": "https://github.com/NVIDIA/dsx-github-actions.git"
+    "url": "https://github.com/dsx-ai-factory/dsx-github-actions.git"
   },
   "keywords": [
     "github-actions",


### PR DESCRIPTION
The Semantic Release workflow was failing verifyConditions with "The git repository URL mismatches the GitHub URL" because `package.json` still pointed `repository.url` at the pre-transfer path.

semantic-release derives `repositoryUrl` from `package.json` (which takes precedence over the git remote) and compares it to the live repo. Repointing it at the current path fixes the mismatch. No behavior change beyond that.

- `package.json`: `repository.url` -> https://github.com/dsx-ai-factory/dsx-github-actions.git

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the package repository link to the new project location.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->